### PR TITLE
Potential fix for code scanning alert no. 2: Stored cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
     "sass": "^1.85.1",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@csstools/postcss-global-data": "^2.1.1",

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { baseURL } from "@/app/resources";
 import { person } from "@/app/resources/content";
 import { formatDate } from "@/app/utils/formatDate";
 import ScrollToHash from "@/components/ScrollToHash";
+import escapeHtml from 'escape-html';
 
 interface WorkParams {
   params: {
@@ -90,19 +91,19 @@ export default function Project({ params }: WorkParams) {
           __html: JSON.stringify({
             "@context": "https://schema.org",
             "@type": "BlogPosting",
-            headline: post.metadata.title,
-            datePublished: post.metadata.publishedAt,
-            dateModified: post.metadata.publishedAt,
-            description: post.metadata.summary,
+            headline: escapeHtml(post.metadata.title),
+            datePublished: escapeHtml(post.metadata.publishedAt),
+            dateModified: escapeHtml(post.metadata.publishedAt),
+            description: escapeHtml(post.metadata.summary),
             image: post.metadata.image
-              ? `https://${baseURL}${post.metadata.image}`
+              ? `https://${baseURL}${escapeHtml(post.metadata.image)}`
               : `https://${baseURL}/og?title=${encodeURIComponent(
-                  post.metadata.title
+                  escapeHtml(post.metadata.title)
                 )}`,
-            url: `https://${baseURL}/work/${post.slug}`,
+            url: `https://${baseURL}/work/${escapeHtml(post.slug)}`,
             author: {
               "@type": "Person",
-              name: person.name,
+              name: escapeHtml(person.name),
             },
           }),
         }}


### PR DESCRIPTION
Potential fix for [https://github.com/dhruvhaldar/portfolio/security/code-scanning/2](https://github.com/dhruvhaldar/portfolio/security/code-scanning/2)

To fix the problem, we need to ensure that any data used in the `dangerouslySetInnerHTML` is properly sanitized. The best way to do this is to use a library that can escape HTML characters to prevent XSS attacks. We will use the `escape-html` library to sanitize the data before it is used in the `dangerouslySetInnerHTML`.

1. Install the `escape-html` library.
2. Import the `escape-html` library in the `src/app/work/[slug]/page.tsx` file.
3. Use the `escape-html` library to sanitize the data before passing it to `JSON.stringify`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
