### PR TITLE
🎨 Palette: Add backspace support to remove tags in TagInput

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-05-23 - Interactive Roles on Containers
 **Learning:** The `Chip` component was unconditionally applying `role="button"` and `tabIndex={0}`, creating invalid HTML (button inside button) and confusing accessibility when used as a static container for removable tags in `TagInput`.
 **Action:** Conditionally apply interactive roles (`button`, `link`, etc.) only when the component actually receives an interaction handler (like `onClick`). For composite components (like tags with remove buttons), ensure the container is static if the interaction is only on the inner button.
+
+## 2025-05-31 - Keyboard Deletion in Tag Inputs
+**Learning:** Users intuitively expect Backspace in an empty tag input to delete the previous tag, mimicking text deletion behavior. Missing this creates friction requiring a context switch to the mouse.
+**Action:** Always implement `Backspace` handling for empty states in list-creation inputs (tags, recipients, chips).

--- a/src/once-ui/components/TagInput.tsx
+++ b/src/once-ui/components/TagInput.tsx
@@ -71,6 +71,9 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
           onChange([...value, inputValue.trim()]);
           setInputValue("");
         }
+      } else if (e.key === "Backspace" && inputValue === "" && value.length > 0) {
+        e.preventDefault();
+        onChange(value.slice(0, -1));
       }
     };
 

--- a/src/once-ui/components/__tests__/TagInput_backspace.test.tsx
+++ b/src/once-ui/components/__tests__/TagInput_backspace.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React, { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { TagInput } from "../TagInput";
+
+const TagInputWrapper = () => {
+  const [tags, setTags] = useState<string[]>(["tag1", "tag2"]);
+  return <TagInput label="Tags" id="tags" value={tags} onChange={setTags} />;
+};
+
+describe("TagInput Backspace Behavior", () => {
+  it("removes the last tag on Backspace when input is empty", () => {
+    render(<TagInputWrapper />);
+    const input = screen.getByRole("textbox");
+
+    // Ensure initial state
+    expect(screen.getByText("tag1")).toBeInTheDocument();
+    expect(screen.getByText("tag2")).toBeInTheDocument();
+
+    // Backspace with empty input
+    fireEvent.keyDown(input, { key: "Backspace" });
+
+    // tag2 should be removed (it's the last one)
+    expect(screen.queryByText("tag2")).not.toBeInTheDocument();
+    // tag1 should still be there
+    expect(screen.getByText("tag1")).toBeInTheDocument();
+  });
+
+  it("does not remove tag on Backspace when input is not empty", () => {
+    render(<TagInputWrapper />);
+    const input = screen.getByRole("textbox");
+
+    // Type something
+    fireEvent.change(input, { target: { value: "a" } });
+
+    // Backspace
+    fireEvent.keyDown(input, { key: "Backspace" });
+
+    // Should still have both tags
+    expect(screen.getByText("tag1")).toBeInTheDocument();
+    expect(screen.getByText("tag2")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
*   💡 **What:** Implemented `Backspace` key handling in the `TagInput` component to remove the last tag when the input field is empty.
*   🎯 **Why:** Users intuitively expect backspace to delete the previous item in a list-creation input (like tags or email recipients). Missing this forces a friction-heavy context switch to the mouse.
*   ♿ **Accessibility:** Enhances keyboard usability for managing tags.
*   ✅ **Verification:** Added `TagInput_backspace.test.tsx` covering the behavior and regression cases. Existing tests passed. Linting passed.
*   📓 **Journal:** Updated `.Jules/palette.md` with learnings about keyboard deletion patterns.

---
*PR created automatically by Jules for task [12994578895819254066](https://jules.google.com/task/12994578895819254066) started by @dhruvhaldar*