### PR TITLE
🎨 Palette: Improve IconButton aria-label fallback for better screen reader accuracy

### DIFF
--- a/src/once-ui/components/IconButton.tsx
+++ b/src/once-ui/components/IconButton.tsx
@@ -131,7 +131,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
         onMouseLeave={() => setIsHover(false)}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        aria-label={tooltip || icon}
+        aria-label={props["aria-label"] || tooltip || (!children ? icon : undefined)}
         {...(!href ? { type: "button" } : {})}
         {...props}
       >


### PR DESCRIPTION
**💡 What:** Updated `IconButton` component's `aria-label` logic to prioritize explicitly passed `aria-label` props, then `tooltip`, and finally only fall back to the `icon` prop if there are no `children`.

**🎯 Why:** Prevent incorrect screen reader announcements when an `IconButton` is used with custom `children` (e.g., an SVG swatch or text) but without a tooltip, avoiding situations where a child graphic is improperly announced as the default icon "refresh".

**♿ Accessibility:** Improves screen reader experience by guaranteeing that generic or visual-only buttons are accurately labeled according to their actual contents or explicitly set descriptions.

---
*PR created automatically by Jules for task [16300316068712452869](https://jules.google.com/task/16300316068712452869) started by @dhruvhaldar*