### PR TITLE
🎨 Palette: Add `aria-required` to Input and Textarea

### DIFF
--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -3,16 +3,16 @@
 import classNames from "classnames";
 import type React from "react";
 import {
-  type InputHTMLAttributes,
-  type ReactNode,
   forwardRef,
+  type InputHTMLAttributes,
   memo,
+  type ReactNode,
   useCallback,
   useMemo,
   useState,
 } from "react";
-import { Flex, Icon, Spinner, Text } from ".";
 import useDebounce from "../hooks/useDebounce";
+import { Flex, Icon, Spinner, Text } from ".";
 import styles from "./Input.module.scss";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -222,6 +222,7 @@ const InputComponent = forwardRef<HTMLInputElement, InputProps>(
               className={inputClassNames}
               aria-describedby={describedBy.length > 0 ? describedBy.join(" ") : undefined}
               aria-invalid={!!displayError}
+              aria-required={props.required ? "true" : undefined}
             />
             {!labelAsPlaceholder && (
               <Text
@@ -291,5 +292,5 @@ InputComponent.displayName = "Input";
 const Input = memo(InputComponent);
 Input.displayName = "Input";
 
-export { Input };
 export type { InputProps };
+export { Input };

--- a/src/once-ui/components/Textarea.tsx
+++ b/src/once-ui/components/Textarea.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import React, {
-  useState,
-  useEffect,
-  forwardRef,
-  TextareaHTMLAttributes,
-  useCallback,
-  ReactNode,
-  memo,
-} from "react";
 import classNames from "classnames";
+import React, {
+  forwardRef,
+  memo,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+import useDebounce from "../hooks/useDebounce";
 import { Flex, Icon, Text } from ".";
 import styles from "./Input.module.scss";
-import useDebounce from "../hooks/useDebounce";
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /** Element ID */
@@ -29,15 +29,15 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   description?: ReactNode;
   /** Border radius */
   radius?:
-  | "none"
-  | "top"
-  | "right"
-  | "bottom"
-  | "left"
-  | "top-left"
-  | "top-right"
-  | "bottom-right"
-  | "bottom-left";
+    | "none"
+    | "top"
+    | "right"
+    | "bottom"
+    | "left"
+    | "top-left"
+    | "top-right"
+    | "bottom-right"
+    | "bottom-left";
   /** Custom class name */
   className?: string;
   /** Prefix element */
@@ -99,11 +99,13 @@ const TextareaComponent = forwardRef<HTMLTextAreaElement, TextareaProps>(
         ? props.value.toString().length
         : props.defaultValue
           ? props.defaultValue.toString().length
-          : 0
+          : 0,
     );
     // Safe length access for controlled component
     const internalLength = isControlled
-      ? (props.value ? props.value.toString().length : 0)
+      ? props.value
+        ? props.value.toString().length
+        : 0
       : internalLengthState;
 
     const [validationError, setValidationError] = useState<ReactNode | null>(null);
@@ -206,15 +208,18 @@ const TextareaComponent = forwardRef<HTMLTextAreaElement, TextareaProps>(
       },
     );
 
-    const handleRef = useCallback((node: HTMLTextAreaElement | null) => {
-      if (typeof ref === "function") {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
-      //@ts-ignore
-      textareaRef.current = node;
-    }, [ref]);
+    const handleRef = useCallback(
+      (node: HTMLTextAreaElement | null) => {
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+        //@ts-expect-error
+        textareaRef.current = node;
+      },
+      [ref],
+    );
 
     return (
       <Flex
@@ -260,6 +265,7 @@ const TextareaComponent = forwardRef<HTMLTextAreaElement, TextareaProps>(
               className={textareaClassNames}
               aria-describedby={describedBy.length > 0 ? describedBy.join(" ") : undefined}
               aria-invalid={!!displayError}
+              aria-required={props.required ? "true" : undefined}
               style={{
                 ...style,
                 resize: lines === "auto" ? "none" : resize,
@@ -314,11 +320,7 @@ const TextareaComponent = forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         {showCount && (
           <Flex paddingX="16" fillWidth horizontal="end">
-            <Text
-              id={countId}
-              variant="body-default-s"
-              onBackground="neutral-weak"
-            >
+            <Text id={countId} variant="body-default-s" onBackground="neutral-weak">
               <span aria-hidden="true">
                 {internalLength} / {props.maxLength || 4096}
               </span>
@@ -339,5 +341,5 @@ TextareaComponent.displayName = "Textarea";
 const Textarea = memo(TextareaComponent);
 Textarea.displayName = "Textarea";
 
-export { Textarea };
 export type { TextareaProps };
+export { Textarea };


### PR DESCRIPTION
🎨 Palette: Add `aria-required` to Input and Textarea

💡 What: Automatically sets the `aria-required="true"` attribute on the underlying native form elements when the `required` prop is passed to `Input` and `Textarea` components.
🎯 Why: Adding a visual indicator (like an asterisk) is not enough. Screen readers need `aria-required` or the native `required` attribute directly on the focusable element to announce the field as mandatory.
♿ Accessibility: Ensures that users relying on assistive technologies are correctly informed when a form field must be completed before submission.

---
*PR created automatically by Jules for task [15917070420050218666](https://jules.google.com/task/15917070420050218666) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced input and textarea components with proper accessibility attributes to improve support for assistive technologies.
  * Form requirement information is now better exposed to screen readers and other assistive devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->