### PR TITLE
🎨 Palette: Enhance ColorInput keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Prevent Keyboard Bubbling on Interactive Details
 **Learning:** Keyboard navigation (Enter/Space) on inner interactive elements like an IconButton tooltip can bubble up to the parent Checkbox/Switch, causing accidental toggling.
 **Action:** When nesting interactive elements inside a clickable row/label, explicitly add `onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation(); }}` to the inner element's wrapper to trap these specific interaction keys without breaking global keys like Escape.
+## 2024-05-18 - ColorInput Prefix/Suffix Keyboard Accessibility
+**Learning:** Custom form elements built with structural wrappers like `<Flex>` for prefixes and suffixes (e.g., color swatches) often miss default keyboard accessibility. Adding an `onClick` handler is not enough; they require explicit `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers listening for 'Enter' or 'Space' to be fully usable by keyboard-only users.
+**Action:** Always check custom interactive elements (prefixes/suffixes) for `role`, `tabIndex`, and `onKeyDown` handlers if they have `onClick` behaviors.

--- a/src/once-ui/components/ColorInput.tsx
+++ b/src/once-ui/components/ColorInput.tsx
@@ -30,6 +30,13 @@ const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
       } as React.ChangeEvent<HTMLInputElement>);
     };
 
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        handleHexClick();
+      }
+    };
+
     return (
       <Input
         style={{ cursor: "pointer" }}
@@ -54,9 +61,13 @@ const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
               </Flex>
             </Flex>
             <Flex
+              role="button"
+              tabIndex={0}
+              aria-label="Select color"
               border="neutral-strong"
               className={`prefix ${value ? "" : "hidden"}`}
               onClick={handleHexClick}
+              onKeyDown={handleKeyDown}
               height="20"
               radius="xs"
               style={{
@@ -81,7 +92,11 @@ const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
             }}
           >
             <Flex
+              role="button"
+              tabIndex={0}
+              aria-label={`Current color is ${value}. Click to select color.`}
               onClick={handleHexClick}
+              onKeyDown={handleKeyDown}
               fillWidth
               style={{
                 opacity: value ? "1" : "0",

--- a/src/once-ui/components/__tests__/ColorInput.test.tsx
+++ b/src/once-ui/components/__tests__/ColorInput.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import React, { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ColorInput } from "../ColorInput";
+
+describe("ColorInput", () => {
+  it("renders label and input", () => {
+    render(<ColorInput id="test-color" label="Test Color" value="#ff0000" onChange={() => {}} />);
+    expect(screen.getByLabelText("Test Color")).toBeInTheDocument();
+  });
+
+  it("triggers color picker on keyboard interaction", () => {
+    const handleChange = vi.fn();
+    render(<ColorInput id="test-color" label="Color" value="#00ff00" onChange={handleChange} />);
+
+    const colorSwatch = screen.getByRole("button", { name: "Select color" });
+
+    // Check if the original input click is triggered when space/enter is pressed on the custom swatch
+    const input = screen.getByLabelText("Color");
+    const clickSpy = vi.spyOn(input, 'click');
+
+    fireEvent.keyDown(colorSwatch, { key: "Enter", code: "Enter", charCode: 13 });
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(colorSwatch, { key: " ", code: "Space", charCode: 32 });
+    expect(clickSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
🎨 Palette: Enhance ColorInput keyboard accessibility

💡 What: Added keyboard support to the color swatch (prefix) and hex display (suffix) in `ColorInput.tsx` by adding `role="button"`, `tabIndex={0}`, `onKeyDown` handlers, and `aria-label`s. Also added corresponding unit tests.
🎯 Why: Previously, these elements only responded to mouse clicks (`onClick`). This change ensures keyboard-only users and screen readers can access and interact with the color picker dialog, improving the component's overall accessibility.
♿ Accessibility: Ensures custom interactive `Flex` elements function semantically as buttons for assistive technologies and keyboard navigation.

---
*PR created automatically by Jules for task [1058974924681447649](https://jules.google.com/task/1058974924681447649) started by @dhruvhaldar*