### PR TITLE
🎨 Palette: Explicit aria-required for custom form inputs

### DIFF
--- a/src/once-ui/components/Input.tsx
+++ b/src/once-ui/components/Input.tsx
@@ -215,6 +215,7 @@ const InputComponent = forwardRef<HTMLInputElement, InputProps>(
               ref={ref}
               id={id}
               aria-busy={loading}
+              aria-required={props.required}
               placeholder={labelAsPlaceholder ? label : props.placeholder}
               onFocus={handleFocus}
               onBlur={handleBlur}

--- a/src/once-ui/components/Textarea.tsx
+++ b/src/once-ui/components/Textarea.tsx
@@ -253,6 +253,7 @@ const TextareaComponent = forwardRef<HTMLTextAreaElement, TextareaProps>(
               {...props}
               ref={handleRef}
               id={id}
+              aria-required={props.required}
               rows={typeof lines === "number" ? lines : 1}
               placeholder={labelAsPlaceholder ? label : props.placeholder}
               onFocus={handleFocus}


### PR DESCRIPTION
💡 What: Explicitly map the `required` prop to the `aria-required="true"` attribute on the underlying native elements in custom form components (`Input` and `Textarea`).
🎯 Why: To ensure assistive technologies announce these fields as mandatory.
♿ Accessibility: Improves screen reader compatibility for required form inputs.

---
*PR created automatically by Jules for task [8750768944118987759](https://jules.google.com/task/8750768944118987759) started by @dhruvhaldar*