### PR TITLE
🎨 Palette: Add accessible loading state to Newsletter subscribe button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Async Button Loading State
+**Learning:** For asynchronous form submissions, the design system's `Button` component provides a native `loading` prop that automatically handles the loading spinner and sets `aria-busy="true"`. Manual implementations (changing text to "Loading..." and setting `disabled`) provide a worse UX and lower accessibility.
+**Action:** Always prefer the `loading` prop over manually toggling text and `disabled` attributes for `Button` components handling async operations.

--- a/src/components/blog/Newsletter.tsx
+++ b/src/components/blog/Newsletter.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { newsletter } from "@/app/resources";
 import { isValidEmail } from "@/app/utils/security";
 import { Button, Column, Flex, Heading, Input, Mask, SmartImage, Text } from "@/once-ui/components";
-import { useState } from "react";
 
 export const Newsletter = () => {
   const [email, setEmail] = useState("");
@@ -29,7 +29,7 @@ export const Newsletter = () => {
     const formData = new FormData(form);
 
     try {
-      const response = await fetch(newsletter.action, {
+      const _response = await fetch(newsletter.action, {
         method: "POST",
         body: formData,
         mode: "no-cors",
@@ -39,7 +39,7 @@ export const Newsletter = () => {
       // This is standard for third-party form endpoints like ConvertKit when submitting from client-side without a proxy.
       setStatus("success");
       setEmail("");
-    } catch (err) {
+    } catch (_err) {
       setStatus("error");
       setError("Something went wrong. Please try again.");
     }
@@ -138,8 +138,8 @@ export const Newsletter = () => {
                     errorMessage={error}
                     maxLength={254}
                   />
-                  <Button fillWidth variant="primary" size="m" disabled={status === "loading"}>
-                    {status === "loading" ? "Subscribing..." : "Subscribe"}
+                  <Button fillWidth variant="primary" size="m" loading={status === "loading"}>
+                    Subscribe
                   </Button>
                 </Flex>
               </form>


### PR DESCRIPTION
💡 **What**: Refactored the newsletter subscription button to use the native `loading` prop instead of manually changing text and `disabled` attributes.

🎯 **Why**: When users submit the form, a visual spinner with the correct `aria-busy="true"` state provides better, more native-feeling visual feedback than simply disabling the button and changing its text.

📸 **Before/After**: Visually verified via Playwright screenshot that the spinner correctly renders inside the button upon submission.

♿ **Accessibility**: Replaces an explicit disabled state with the proper `aria-busy="true"` loading state handled by the design system's `Button` component.

---
*PR created automatically by Jules for task [8979198512663983366](https://jules.google.com/task/8979198512663983366) started by @dhruvhaldar*