### PR TITLE
🎨 Palette: Add `aria-haspopup` to UserMenu Trigger

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
+## 2025-06-03 - Added aria-haspopup to UserMenu trigger
+**Learning:** Custom menu triggers built with generic elements (like `<Flex role="button">`) require `aria-haspopup="menu"` so screen readers announce that activating the button will open a sub-menu.
+**Action:** Always verify that interactive elements serving as menu triggers have both `role="button"` and `aria-haspopup="menu"`.
 ## 2025-06-02 - Removed redundant aria-required
 **Learning:** In React components that spread `...props` onto native form elements like `<input>` or `<textarea>`, explicitly setting `aria-required={props.required}` causes the native `required` attribute and the ARIA attribute to both be applied, leading to duplicate screen reader announcements.
 **Action:** Avoid applying `aria-required` if the component already forwards standard HTML boolean attributes.

--- a/src/once-ui/components/UserMenu.tsx
+++ b/src/once-ui/components/UserMenu.tsx
@@ -44,6 +44,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
         <Flex
           tabIndex={0}
           role="button"
+          aria-haspopup="menu"
           aria-label={userProps.name ? `User menu for ${userProps.name}` : "User menu"}
           direction="column"
           padding="4"


### PR DESCRIPTION
🎨 **Palette: Added `aria-haspopup` to UserMenu Trigger**

💡 **What**:
Added the `aria-haspopup="menu"` attribute to the trigger element of the `UserMenu` component.

🎯 **Why**:
The `UserMenu` acts as a button that opens a dropdown menu. While it correctly used `role="button"` and `tabIndex={0}`, it was missing the `aria-haspopup` attribute. Adding this allows screen readers to proactively inform users that activating the button will open a sub-menu, rather than leaving them to guess the button's action. 

📸 **Before/After**:
No visual changes. Purely semantic markup update for assistive technologies.

♿ **Accessibility**:
Improved ARIA compliance for custom interactive dropdown triggers.

---
*PR created automatically by Jules for task [11663877047429798382](https://jules.google.com/task/11663877047429798382) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility Improvements**
  * Enhanced the user menu component with proper accessibility attributes, improving compatibility with screen readers and assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->