### PR TITLE
🎨 Palette: Add accessible empty state announcements to Select component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-30 - Carousel Active State Announcement
-**Learning:** Adding interactive navigation buttons inside a Carousel component requires `aria-current="true"` to accurately communicate which slide is currently active to screen reader users, rather than relying solely on visual cues like background color or borders.
-**Action:** Ensure that all components representing an active/selected state in a set (like pagination dots, thumbnails, or tab panels) explicitly set `aria-current="true"` (or `aria-selected` / `aria-pressed` as appropriate for their role) when active.
+## 2024-06-20 - [Added Accessible Empty State to Select]
+**Learning:** Empty states resulting from dynamic filtering (like a search within a Select component) are visually apparent but completely invisible to screen readers unless explicitly marked up.
+**Action:** Always wrap dynamically rendered empty states in a container with `role="status"` and `aria-live="polite"` to proactively inform assistive technology users of zero-result states.

--- a/src/once-ui/components/Select.tsx
+++ b/src/once-ui/components/Select.tsx
@@ -302,7 +302,15 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
                 />
               ))}
               {filteredOptions.length === 0 && (
-                <Flex fillWidth vertical="center" horizontal="center" paddingX="16" paddingY="32">
+                <Flex
+                  fillWidth
+                  vertical="center"
+                  horizontal="center"
+                  paddingX="16"
+                  paddingY="32"
+                  role="status"
+                  aria-live="polite"
+                >
                   {emptyState}
                 </Flex>
               )}


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` and `role="status"` to the empty state container in the `Select` component.
🎯 Why: To ensure screen readers announce "No results" (or custom empty state text) when filtering yields no matches.
📸 Before/After: Visuals unchanged; structural ARIA attributes added.
♿ Accessibility: Screen reader users now receive explicit feedback when a search returns no options.

---
*PR created automatically by Jules for task [11151535362676559112](https://jules.google.com/task/11151535362676559112) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility**
  * Select component empty states are now announced to screen readers via updated ARIA attributes, providing better feedback when no results are available.

* **Documentation**
  * Updated accessibility guidelines with implementation guidance for Select component empty state announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->