### PR TITLE
🎨 Palette: Add global Escape key dismissal for Toast notifications

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-20 - [Added Accessible Empty State to Select]
 **Learning:** Empty states resulting from dynamic filtering (like a search within a Select component) are visually apparent but completely invisible to screen readers unless explicitly marked up.
 **Action:** Always wrap dynamically rendered empty states in a container with `role="status"` and `aria-live="polite"` to proactively inform assistive technology users of zero-result states.
+## 2024-03-24 - Toast Global Escape Dismissal
+**Learning:** `Toast` components with inline `onKeyDown` listeners checking for the `Escape` key are inaccessible if the container doesn't natively receive focus (or lack a `tabIndex`).
+**Action:** Always implement global dismissal (using a `document.addEventListener('keydown')` inside a `useEffect`) for transient status alerts/notifications like toasts so keyboard users can dismiss them without having to chase focus.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7560,7 +7560,7 @@ snapshots:
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2)
@@ -7593,7 +7593,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7608,7 +7608,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/src/once-ui/components/Toast.tsx
+++ b/src/once-ui/components/Toast.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useEffect, useState, forwardRef } from "react";
-import { IconButton, Icon, Flex, Text } from ".";
 import classNames from "classnames";
+import type React from "react";
+import { forwardRef, useEffect, useState } from "react";
+import { Flex, Icon, IconButton, Text } from ".";
 import styles from "./Toast.module.scss";
 
 interface ToastProps {
@@ -57,6 +58,20 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
       }
     }, [visible, onClose]);
 
+    // Palette: Allow dismissing toast with Escape key for accessibility globally
+    useEffect(() => {
+      if (!visible) return;
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          setVisible(false);
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [visible]);
+
     const { role, ariaLive } = accessibilityMap[variant];
 
     return (
@@ -78,12 +93,6 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
         onMouseLeave={() => setIsPaused(false)}
         onFocus={() => setIsPaused(true)}
         onBlur={() => setIsPaused(false)}
-        onKeyDown={(e) => {
-          // Palette: Allow dismissing toast with Escape key for accessibility
-          if (e.key === "Escape") {
-            setVisible(false);
-          }
-        }}
       >
         <Flex fillWidth vertical="center" gap="8">
           {icon && <Icon size="l" onBackground={`${variant}-medium`} name={iconMap[variant]} />}


### PR DESCRIPTION
Implemented a global Escape keydown listener to allow users to dismiss Toast notifications from anywhere on the page, addressing an accessibility issue where the previous inline `onKeyDown` listener was unreachable because the Toast container did not naturally receive focus.

---
*PR created automatically by Jules for task [4409567460985619046](https://jules.google.com/task/4409567460985619046) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now dismiss reliably when users press Escape, with proper focus handling for keyboard accessibility.

* **Documentation**
  * Added guidance for implementing global keyboard listeners to dismiss toasts using Escape key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->