### PR TITLE
🎨 Palette: Add `aria-describedby` to Dialog for better accessibility

### DIFF
--- a/src/once-ui/components/Dialog.tsx
+++ b/src/once-ui/components/Dialog.tsx
@@ -249,6 +249,7 @@ const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
         role="dialog"
         aria-modal="true"
         aria-labelledby="dialog-title"
+        aria-describedby={description ? "dialog-description" : undefined}
       >
         <Flex
           fill
@@ -319,7 +320,7 @@ const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
                 />
               </Flex>
               {description && (
-                <Text variant="body-default-s" onBackground="neutral-weak">
+                <Text id="dialog-description" variant="body-default-s" onBackground="neutral-weak">
                   {description}
                 </Text>
               )}


### PR DESCRIPTION
💡 What: Added the `aria-describedby` attribute to the `Dialog` component.
🎯 Why: Ensures that screen readers proactively announce the dialog's description text upon opening without the user needing to manually focus the text element.
♿ Accessibility: Directly targets an accessibility pattern to provide context for visually impaired users.

---
*PR created automatically by Jules for task [5970119634923821158](https://jules.google.com/task/5970119634923821158) started by @dhruvhaldar*