### PR TITLE
🎨 Palette: Add aria-describedby to link Tooltips with their button triggers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-07-03 - [SmartLink aria-current]
 **Learning:** For site-wide navigation (e.g., in Header), applying conditional styles or underlines for active states is insufficient for assistive technologies. We need semantic attributes like `aria-current="page"` to broadcast the active route. Since `SmartLink` is often used to wrap Next.js Links with custom styling based on an explicit `selected` prop, we should utilize this prop to also handle `aria-current`.
 **Action:** When creating navigational components or link wrappers with explicit active/selected states, map that state directly to the appropriate `aria-current` or `aria-selected` attributes automatically to ensure accessibility wins site-wide.
+## 2024-05-14 - Dynamic Tooltip Accessibility Linking
+**Learning:** Screen readers cannot infer the relationship between a button and its custom tooltip unless they are explicitly linked, even if the tooltip renders directly near the button in the DOM. Relying solely on `aria-label` often duplicates text or masks actual visual tooltip content from assistive technologies.
+**Action:** When a button triggers a custom `Tooltip`, generate a unique ID using React's `useId()` and conditionally apply `aria-describedby` to the button trigger that points to the tooltip's ID when the tooltip is rendered.

--- a/src/once-ui/components/IconButton.tsx
+++ b/src/once-ui/components/IconButton.tsx
@@ -2,7 +2,7 @@
 
 import classNames from "classnames";
 import type React from "react";
-import { forwardRef, type ReactNode, useEffect, useState } from "react";
+import { forwardRef, type ReactNode, useEffect, useState, useId } from "react";
 import { Flex, Icon, Tooltip } from ".";
 import buttonStyles from "./Button.module.scss";
 import { ElementType } from "./ElementType";
@@ -71,6 +71,9 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
     const [isTooltipVisible, setTooltipVisible] = useState(false);
     const [isHover, setIsHover] = useState(false);
 
+    const generatedId = useId();
+    const tooltipId = tooltip ? `${id || generatedId}-tooltip` : undefined;
+
     const handleFocus = (event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>) => {
       setIsHover(true);
       if (onFocus) onFocus(event as any);
@@ -99,7 +102,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
         {children ? children : <Icon name={icon} size="s" />}
         {tooltip && isTooltipVisible && (
           <Flex position="absolute" zIndex={1} className={iconStyles[tooltipPosition]}>
-            <Tooltip label={tooltip} />
+            <Tooltip id={tooltipId} label={tooltip} />
           </Flex>
         )}
       </>
@@ -114,6 +117,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps | AnchorProps>(
         href={href}
         ref={ref}
         aria-disabled={isDisabled ? "true" : undefined}
+        aria-describedby={tooltip && isTooltipVisible ? tooltipId : undefined}
         className={classNames(
           buttonStyles.button,
           buttonStyles[variant],

--- a/src/once-ui/components/ToggleButton.tsx
+++ b/src/once-ui/components/ToggleButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { forwardRef, ReactNode, useState, useEffect, memo } from "react";
+import React, { forwardRef, ReactNode, useState, useEffect, memo, useId } from "react";
 import classNames from "classnames";
 import { ElementType } from "./ElementType";
 import { Flex, Icon, Tooltip } from ".";
@@ -87,6 +87,9 @@ const ToggleButtonComponent = forwardRef<HTMLElement, ToggleButtonProps>(
     const [isTooltipVisible, setTooltipVisible] = useState(false);
     const [isHover, setIsHover] = useState(false);
 
+    const generatedId = useId();
+    const tooltipId = tooltip ? `${props.id || generatedId}-tooltip` : undefined;
+
     const handleFocus = (event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>) => {
       setIsHover(true);
       if (onFocus) onFocus(event as any);
@@ -142,6 +145,7 @@ const ToggleButtonComponent = forwardRef<HTMLElement, ToggleButtonProps>(
         aria-label={!label && !children ? tooltip || prefixIcon || suffixIcon : undefined}
         aria-pressed={!href && (!props.role || props.role === "button") ? selected : undefined}
         aria-current={href && selected ? "page" : undefined}
+        aria-describedby={tooltip && isTooltipVisible ? tooltipId : undefined}
         {...props}
       >
         {prefixIcon && <Icon name={prefixIcon} size={size === "l" ? "m" : "s"} />}
@@ -158,7 +162,7 @@ const ToggleButtonComponent = forwardRef<HTMLElement, ToggleButtonProps>(
         {suffixIcon && <Icon name={suffixIcon} size={size === "l" ? "m" : "s"} />}
         {tooltip && isTooltipVisible && (
           <Flex position="absolute" zIndex={1} className={iconStyles[tooltipPosition]}>
-            <Tooltip label={tooltip} />
+            <Tooltip id={tooltipId} label={tooltip} />
           </Flex>
         )}
       </ElementType>

--- a/src/once-ui/components/Tooltip.tsx
+++ b/src/once-ui/components/Tooltip.tsx
@@ -6,6 +6,8 @@ import classNames from "classnames";
 import { Flex, Icon } from ".";
 
 type TooltipProps = {
+  /** ID for accessibility */
+  id?: string;
   /** Tooltip text/content */
   label: ReactNode;
   /** Icon before text */
@@ -22,9 +24,10 @@ type TooltipProps = {
  * A tooltip component for displaying additional information on hover/focus.
  */
 const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
-  ({ label, prefixIcon, suffixIcon, className, style }, ref) => {
+  ({ id, label, prefixIcon, suffixIcon, className, style }, ref) => {
     return (
       <Flex
+        id={id}
         hide="m"
         ref={ref}
         style={{


### PR DESCRIPTION
💡 **What:** Added `id` prop to `Tooltip` and updated `IconButton`/`ToggleButton` to dynamically map their tooltip using `aria-describedby` and `useId()`.
🎯 **Why:** To ensure screen readers announce custom tooltips correctly by explicitly associating the floating tooltip element with its button trigger when conditionally rendered.
♿ **Accessibility:** Improves context for screen reader users by properly linking floating tooltips using the native WAI-ARIA `aria-describedby` relationship pattern.

---
*PR created automatically by Jules for task [3055613367281413934](https://jules.google.com/task/3055613367281413934) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tooltip accessibility for button-style controls by linking triggers to their tooltip content.
  - Added stable tooltip identifiers so assistive technologies can better associate controls with visible tooltips.

- **Bug Fixes**
  - Updated tooltip behavior for icon and toggle buttons so the tooltip relationship is only announced when the tooltip is shown.
  - Strengthened accessibility support without changing the visible user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->