### PR TITLE
🎨 Palette: Improve Dropdown Accessibility in UserMenu

### DIFF
--- a/src/once-ui/components/UserMenu.tsx
+++ b/src/once-ui/components/UserMenu.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import React from "react";
 import classNames from "classnames";
-import { Flex, DropdownWrapper, User, UserProps } from ".";
+import type React from "react";
+import { DropdownWrapper, Flex, User, type UserProps } from ".";
+import type { DropdownWrapperProps } from "./DropdownWrapper";
 import styles from "./UserMenu.module.scss";
-import { DropdownWrapperProps } from "./DropdownWrapper";
 
 interface UserMenuProps
   extends UserProps,
-  Pick<DropdownWrapperProps, "minHeight" | "minWidth" | "maxWidth"> {
+    Pick<DropdownWrapperProps, "minHeight" | "minWidth" | "maxWidth"> {
   /** Selected state */
   selected?: boolean;
   /** Dropdown content */
@@ -34,6 +34,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
 }) => {
   return (
     <DropdownWrapper
+      dropdownRole="menu"
       minWidth={minWidth}
       maxWidth={maxWidth}
       minHeight={minHeight}
@@ -58,10 +59,11 @@ const UserMenu: React.FC<UserMenuProps> = ({
           <User {...userProps} />
         </Flex>
       }
-      dropdown={<>{dropdown}</>}
+      dropdown={dropdown}
     />
   );
 };
 
 UserMenu.displayName = "UserMenu";
+
 export { UserMenu };


### PR DESCRIPTION
🎨 Palette: Improved Dropdown Accessibility in UserMenu

💡 What: Added the `dropdownRole="menu"` property to the `DropdownWrapper` call within the `UserMenu` component.
🎯 Why: The `UserMenu` trigger `Flex` component explicitly uses `aria-haspopup="menu"`. However, without passing `dropdownRole="menu"`, the `DropdownWrapper` defaults to assigning `role="listbox"` to the opened dropdown container. This created an invalid ARIA pattern where a menu trigger opened a listbox, which can confuse screen reader users. Ensuring the popup type accurately matches the dropdown container's role creates a cohesive and accessible experience.
♿ Accessibility: Ensures that assistive technologies announce the dropdown as a proper menu, matching the trigger's `aria-haspopup` property.

---
*PR created automatically by Jules for task [9275765105730334984](https://jules.google.com/task/9275765105730334984) started by @dhruvhaldar*