### PR TITLE
🎨 Palette: Fix Accordion inert attribute for improved accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-14 - Dynamic Tooltip Accessibility Linking
 **Learning:** Screen readers cannot infer the relationship between a button and its custom tooltip unless they are explicitly linked, even if the tooltip renders directly near the button in the DOM. Relying solely on `aria-label` often duplicates text or masks actual visual tooltip content from assistive technologies.
 **Action:** When a button triggers a custom `Tooltip`, generate a unique ID using React's `useId()` and conditionally apply `aria-describedby` to the button trigger that points to the tooltip's ID when the tooltip is rendered.
+
+## 2025-07-03 - React inert attribute behavior
+**Learning:** When using the `inert` attribute in React to hide content from assistive technologies (like in a closed `Accordion` or behind a `Dialog`), React expects a boolean value (`inert={true}` or `inert={false}`) rather than a string (`inert="true"`). Passing a string causes React to throw a warning and may result in the attribute not being applied correctly to the DOM, potentially breaking keyboard/screen reader accessibility.
+**Action:** Always pass boolean values to the `inert` attribute in JSX to ensure closed or hidden content is truly removed from the accessibility tree.

--- a/src/once-ui/components/Accordion.tsx
+++ b/src/once-ui/components/Accordion.tsx
@@ -92,7 +92,7 @@ const Accordion: React.FC<AccordionProps> = forwardRef(
           }}
           aria-hidden={!isOpen}
           // @ts-expect-error: inert is a valid HTML attribute but might be missing from some React type definitions
-          inert={!isOpen ? "true" : undefined}
+          inert={!isOpen ? true : undefined}
         >
           <Flex fillWidth minHeight={0} overflow="hidden">
             <Column fillWidth paddingX="20" paddingTop="8" paddingBottom="16" {...rest}>


### PR DESCRIPTION
💡 **What:** Fixed the `inert` attribute on the Accordion component to use a boolean instead of a string.
🎯 **Why:** React expects a boolean for the `inert` attribute. Passing a string was causing warnings and potentially breaking accessibility by not correctly making hidden content un-focusable.
♿ **Accessibility:** Ensures hidden accordion content is correctly marked as inert in React, preventing screen readers and keyboard users from accessing collapsed content.

---
*PR created automatically by Jules for task [17879602684850157539](https://jules.google.com/task/17879602684850157539) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accordion accessibility by correctly excluding collapsed content from the accessibility tree.
  * Prevented React warnings related to the accordion’s `inert` attribute.

* **Documentation**
  * Added guidance on using the `inert` attribute with boolean values in React.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->